### PR TITLE
chore: bump version to 0.1.2-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight Java SDK for the Apple Maps Server API, with automatic access-toke
 
 ## Installation
 
-Replace `0.1.1` with the latest release.
+Replace `0.1.2` with the latest release.
 
 Note: this repo’s build uses a Gradle Java toolchain (Java 17). If you don’t have JDK 17 installed locally, Gradle will download it automatically.
 
@@ -18,7 +18,7 @@ Note: this repo’s build uses a Gradle Java toolchain (Java 17). If you don’t
 
 ```groovy
 dependencies {
-    implementation("com.williamcallahan:apple-maps-java:0.1.1")
+    implementation("com.williamcallahan:apple-maps-java:0.1.2")
 }
 ```
 
@@ -28,7 +28,7 @@ dependencies {
 <dependency>
   <groupId>com.williamcallahan</groupId>
   <artifactId>apple-maps-java</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight Java SDK for the Apple Maps Server API, with automatic access-toke
 
 ## Installation
 
-Replace `0.1.0` with the latest release.
+Replace `0.1.1` with the latest release.
 
 Note: this repo’s build uses a Gradle Java toolchain (Java 17). If you don’t have JDK 17 installed locally, Gradle will download it automatically.
 
@@ -18,7 +18,7 @@ Note: this repo’s build uses a Gradle Java toolchain (Java 17). If you don’t
 
 ```groovy
 dependencies {
-    implementation("com.williamcallahan:apple-maps-java:0.1.0")
+    implementation("com.williamcallahan:apple-maps-java:0.1.1")
 }
 ```
 
@@ -28,7 +28,7 @@ dependencies {
 <dependency>
   <groupId>com.williamcallahan</groupId>
   <artifactId>apple-maps-java</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ val javaTargetVersion = 17
 group = providers.gradleProperty("GROUP").orNull ?: "com.williamcallahan"
 version = providers.gradleProperty("version").orNull
     ?: providers.gradleProperty("VERSION_NAME").orNull
-    ?: "0.1.1"
+    ?: "0.1.2"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ val javaTargetVersion = 17
 group = providers.gradleProperty("GROUP").orNull ?: "com.williamcallahan"
 version = providers.gradleProperty("version").orNull
     ?: providers.gradleProperty("VERSION_NAME").orNull
-    ?: "0.1.0"
+    ?: "0.1.1"
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.williamcallahan
 POM_ARTIFACT_ID=apple-maps-java
-VERSION_NAME=0.1.1-SNAPSHOT
+VERSION_NAME=0.1.2-SNAPSHOT
 
 POM_NAME=Apple Maps Java
 POM_DESCRIPTION=Apple Maps Java implements the Apple Maps Server API for use in JVMs.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.williamcallahan
 POM_ARTIFACT_ID=apple-maps-java
-VERSION_NAME=0.1.0
+VERSION_NAME=0.1.1-SNAPSHOT
 
 POM_NAME=Apple Maps Java
 POM_DESCRIPTION=Apple Maps Java implements the Apple Maps Server API for use in JVMs.


### PR DESCRIPTION
Bump project version from 0.1.0 to 0.1.2-SNAPSHOT to prepare for the next development cycle.

## Version updates
- Update `VERSION_NAME` in `gradle.properties` from `0.1.0` to `0.1.2-SNAPSHOT`
- Update fallback version in `build.gradle.kts` from `0.1.0` to `0.1.2`

## Documentation updates
- Update Gradle dependency example in `README.md` to `0.1.2`
- Update Maven dependency example in `README.md` to `0.1.2`