### PR TITLE
chore: migrate to nmcp plugin with explicit GPG signing for Maven Central

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,9 +39,8 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: ./gradlew publishAllPublicationsToMavenCentralRepository -x test
 
       - name: Update dependency graph

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,20 +28,15 @@ jobs:
 
       - name: Build and test
         run: ./gradlew build
-      - name: Read version
-        id: version
-        run: |
-          VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Publish SNAPSHOT (main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && endsWith(steps.version.outputs.VERSION, 'SNAPSHOT')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository -x test
+        run: ./gradlew publishAllPublicationsToCentralPortalSnapshots -x test
 
       - name: Update dependency graph
         uses: gradle/actions/dependency-submission@v5

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -13,9 +13,8 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
-      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -11,8 +11,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -45,4 +45,4 @@ jobs:
         run: ./gradlew build -Pversion=${{ steps.version.outputs.VERSION }}
 
       - name: Deploy to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository -Pversion=${{ steps.version.outputs.VERSION }}
+        run: ./gradlew publishAllPublicationsToCentralPortal -Pversion=${{ steps.version.outputs.VERSION }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ import java.io.FileInputStream
 plugins {
     id("com.vanniktech.maven.publish") version "0.35.0"
     `java-library`
+    signing
 }
 
 // Load .env file if it exists
@@ -162,7 +163,16 @@ tasks.withType<Javadoc>().configureEach {
 
 mavenPublishing {
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
+}
+
+// Manual signing configuration using environment variables
+signing {
+    val signingKey = providers.environmentVariable("GPG_PRIVATE_KEY").orNull
+    val signingPassword = providers.environmentVariable("GPG_PASSPHRASE").orNull
+    if (signingKey != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword ?: "")
+        sign(publishing.publications)
+    }
 }
 
 // Fix task dependency issue with Gradle 9.x and vanniktech plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,10 @@ import java.util.Properties
 import java.io.FileInputStream
 
 plugins {
-    id("com.vanniktech.maven.publish") version "0.35.0"
     `java-library`
+    `maven-publish`
     signing
+    id("com.gradleup.nmcp") version "1.2.1"
 }
 
 // Load .env file if it exists
@@ -161,21 +162,69 @@ tasks.withType<Javadoc>().configureEach {
     (options as StandardJavadocDocletOptions).addStringOption("-release", javaTargetVersion.toString())
 }
 
-mavenPublishing {
-    publishToMavenCentral(automaticRelease = true)
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = providers.gradleProperty("POM_ARTIFACT_ID").orNull ?: "apple-maps-java"
+
+            pom {
+                name.set(providers.gradleProperty("POM_NAME").orNull ?: "Apple Maps Java")
+                description.set(providers.gradleProperty("POM_DESCRIPTION").orNull ?: "Apple Maps Java implements the Apple Maps Server API for use in JVMs.")
+                url.set(providers.gradleProperty("POM_URL").orNull ?: "https://github.com/WilliamAGH/apple-maps-java")
+
+                licenses {
+                    license {
+                        name.set(providers.gradleProperty("POM_LICENSE_NAME").orNull ?: "MIT License")
+                        url.set(providers.gradleProperty("POM_LICENSE_URL").orNull ?: "https://opensource.org/license/mit")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set(providers.gradleProperty("POM_DEVELOPER_ID").orNull ?: "WilliamAGH")
+                        name.set(providers.gradleProperty("POM_DEVELOPER_NAME").orNull ?: "William Callahan")
+                        url.set(providers.gradleProperty("POM_DEVELOPER_URL").orNull ?: "https://github.com/WilliamAGH/")
+                    }
+                }
+
+                scm {
+                    url.set(providers.gradleProperty("POM_SCM_URL").orNull ?: "https://github.com/WilliamAGH/apple-maps-java")
+                    connection.set(providers.gradleProperty("POM_SCM_CONNECTION").orNull ?: "scm:git:git://github.com/WilliamAGH/apple-maps-java.git")
+                    developerConnection.set(providers.gradleProperty("POM_SCM_DEV_CONNECTION").orNull ?: "scm:git:ssh://git@github.com/WilliamAGH/apple-maps-java.git")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            val releasesUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            val snapshotsUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            url = if (version.toString().endsWith("SNAPSHOT")) snapshotsUrl else releasesUrl
+
+            credentials {
+                username = providers.environmentVariable("SONATYPE_USERNAME").orNull
+                password = providers.environmentVariable("SONATYPE_PASSWORD").orNull
+            }
+        }
+    }
 }
 
-// Manual signing configuration using environment variables
 signing {
     val signingKey = providers.environmentVariable("GPG_PRIVATE_KEY").orNull
     val signingPassword = providers.environmentVariable("GPG_PASSPHRASE").orNull
-    if (signingKey != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword ?: "")
+
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
         sign(publishing.publications)
     }
 }
 
-// Fix task dependency issue with Gradle 9.x and vanniktech plugin
-tasks.matching { it.name == "generateMetadataFileForMavenPublication" }.configureEach {
-    dependsOn(tasks.matching { it.name == "plainJavadocJar" })
+nmcp {
+    publishAllPublicationsToCentralPortal {
+        username.set(providers.environmentVariable("SONATYPE_USERNAME").orNull)
+        password.set(providers.environmentVariable("SONATYPE_PASSWORD").orNull)
+        publishingType.set("USER_MANAGED")
+    }
 }


### PR DESCRIPTION
Migrate from the vanniktech maven-publish plugin to nmcp (New Maven Central Portal) with explicit `maven-publish` and `signing` Gradle plugins. This provides direct control over the publishing configuration and aligns with the Central Portal API.

## Refactoring

- **Replace vanniktech plugin with nmcp + maven-publish** - Removes dependency on the vanniktech abstraction layer in favor of explicit Gradle `maven-publish` and `signing` plugins, matching the approach used in tui4j
- **Switch to in-memory GPG signing** - Use `useInMemoryPgpKeys()` with `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` environment variables instead of the previous `signingInMemoryKey`/`signingInMemoryKeyId`/`signingInMemoryKeyPassword` convention
- **Update publishing tasks** - Change from `publishAllPublicationsToMavenCentralRepository` to `publishAllPublicationsToCentralPortal` (releases) and `publishAllPublicationsToCentralPortalSnapshots` (snapshots)

## Other changes

- Update GitHub Actions to `actions/checkout@v6` and `gradle/actions/setup-gradle@v5`
- Simplify SNAPSHOT publishing condition (remove version extraction step)
- Consolidate environment variable names: `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`