### PR TITLE
ci: prevent SNAPSHOT releases; bump to 0.1.6-SNAPSHOT

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,21 +29,25 @@ jobs:
       - name: Build and test
         run: ./gradlew build
 
-      - name: Extract snapshot version
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        id: snapshot
+      - name: Check if SNAPSHOT version
+        id: version_check
         run: |
           VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d'=' -f2)
-          echo "VERSION=${VERSION}-SNAPSHOT" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Publish SNAPSHOT (main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.version_check.outputs.is_snapshot == 'true'
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: ./gradlew publishAllPublicationsToCentralPortalSnapshots -Pversion=${{ steps.snapshot.outputs.VERSION }} -x test
+        run: ./gradlew publishAllPublicationsToCentralPortalSnapshots -x test
 
       - name: Update dependency graph
         uses: gradle/actions/dependency-submission@v5

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -47,6 +47,18 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Release version: $VERSION"
 
+      - name: Fail if SNAPSHOT tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "::error::Refusing to publish SNAPSHOT version '$VERSION' with the release workflow."
+            echo "::error::Create a non-SNAPSHOT release tag (e.g., v0.1.5) for Maven Central releases."
+            echo "::error::For snapshots, push a -SNAPSHOT version on main and publish via publishAllPublicationsToCentralPortalSnapshots."
+            exit 1
+          fi
+
       - name: Build and test
         run: ./gradlew build -Pversion=${{ steps.version.outputs.VERSION }}
 

--- a/.github/workflows/UpdateReadmeVersion.yaml
+++ b/.github/workflows/UpdateReadmeVersion.yaml
@@ -20,8 +20,10 @@ jobs:
   update-readme:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout default branch
         uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Resolve latest release version from Maven Central metadata
         id: resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,14 @@ alwaysApply: true
 
 ## Rule Summary [SUM]
 
-- [GT1a-d] Git & Permissions (elevated-only git; no destructive commands)
-- [FS1a-g] File Creation & Type Safety (typed records, no maps, no raw types)
+- [ZA1a-d] Zero Tolerance Policy (zero assumptions, validation, forbidden practices, dependency verification)
+- [GT1a-h] Git & Permissions (elevated-only git; no destructive commands)
+- [CC1a-d] Clean Code & DDD (Mandatory)
+- [ID1a-d] Idiomatic Patterns & Defaults
+- [DS1a-e] Dependency Source Verification
+- [FS1a-h] File Creation & Type Safety (typed records, no maps, no raw types)
+- [LOC1a-e] Line Count Ceiling (350 lines max; SRP enforcer; zero tolerance)
+- [MO1a-g] No Monoliths (Strict SRP; Decision Logic; Extension/OCP)
 - [ND1a-c] Naming Discipline (intent-revealing identifiers only)
 - [AB1a-c] Abstraction Discipline (YAGNI; no anemic wrappers; earn reuse)
 - [CS1a-f] Code Smells / Clean Code (DRY; primitive obsession; magic literals)
@@ -24,12 +30,47 @@ alwaysApply: true
 - [TS1a-d] Testing Standards (coverage mandatory; observable behavior; refactor-resilient)
 - [VR1a-c] Verification Loops (build/test/lint steps)
 
+## [ZA1] Zero Tolerance Policy
+
+- [ZA1a] **Zero Assumptions**: Do not assume behavior, APIs, or versions. Verify in the codebase/docs first.
+- [ZA1b] **Source Verification**: For dependency code questions, inspect `~/.m2` JARs or `~/.gradle/caches/` first; fallback to upstream GitHub; never answer without referencing code.
+- [ZA1c] **Forbidden Practices**:
+  - No `Map<String, Object>`, raw types, unchecked casts, `@SuppressWarnings`, or `eslint-disable` in production.
+  - No trusting memory—verify every import/API/config against current docs.
+- [ZA1d] **Mandatory Research**: You MUST research dependency questions and correct usage. Never use legacy or `@deprecated` usage from dependencies. Ensure correct usage by reviewing related code directly in `node_modules` or Gradle caches and using online tool calls.
+
 ## [GT1] Git & Permissions
 
 - [GT1a] All git commands require elevated permissions; never run without escalation.
-- [GT1b] Never remove `.git/index.lock` automatically—stop and ask the user.
-- [GT1c] No destructive git commands (`git restore`, `git reset`, force checkout) unless explicitly ordered.
-- [GT1d] Do not skip commit signing or hooks; no `--no-verify`.
+- [GT1b] Never remove `.git/index.lock` automatically—stop and ask the user or seek explicit approval.
+- [GT1c] Read-only git commands (e.g., `git status`, `git diff`, `git log`, `git show`) never require permission. Any git command that writes to the working tree, index, or history requires explicit permission.
+- [GT1d] Do not skip commit signing or hooks; no `--no-verify`. No `Co-authored-by` or AI attribution.
+- [GT1e] Destructive git commands are prohibited unless explicitly ordered by the user (e.g., `git restore`, `git reset`, force checkout).
+- [GT1f] Treat existing staged/unstaged changes as intentional unless the user says otherwise; never “clean up” someone else’s work unprompted.
+- [GT1g] Examples of write operations that require permission: `git add`, `git commit`, `git checkout`, `git merge`, `git rebase`, `git reset`, `git restore`, `git clean`, `git cherry-pick`.
+- [GT1h] When in doubt whether a git command writes, treat it as write and request explicit approval.
+
+## [CC1] Clean Code & DDD (Mandatory)
+
+- [CC1a] **Mandatory Principles**: Clean Code principles (Robert C. Martin) and Domain-Driven Design (DDD) are **mandatory** and required in this repository.
+- [CC1b] **DRY (Don't Repeat Yourself)**: Avoid redundant code. Reuse code where appropriate and consistent with clean code principles.
+- [CC1c] **YAGNI (You Aren't Gonna Need It)**: Do not build features or abstractions "just in case". Implement only what is required for the current task.
+- [CC1d] **Clean Architecture**: Dependencies point inward. Domain logic has zero framework imports.
+
+## [ID1] Idiomatic Patterns & Defaults
+
+- [ID1a] **Defaults First**: Always prefer the idiomatic, expected, and default patterns provided by the framework, library, or SDK (Java 21+, etc.).
+- [ID1b] **Custom Justification**: Custom implementations require a compelling reason. If you can't justify it, use the standard way.
+- [ID1c] **No Reinventing**: Do not build custom utilities for things the platform already does.
+- [ID1d] **Dependencies**: Make careful use of dependencies. Do not make assumptions—use the correct idiomatic behavior to avoid boilerplate.
+
+## [DS1] Dependency Source Verification
+
+- [DS1a] **Locate**: Find source JARs in Gradle cache: `find ~/.gradle/caches/modules-2/files-2.1 -name "*-sources.jar" | grep <artifact>`.
+- [DS1b] **List**: View JAR contents without extraction: `unzip -l <jar_path> | grep <ClassName>`.
+- [DS1c] **Read**: Pipe specific file content to stdout: `unzip -p <jar_path> <internal/path/to/Class.java>`.
+- [DS1d] **Search**: To use `ast-grep` on dependencies, pipe content directly: `unzip -p <jar> <file> | ast-grep run --pattern '...' --lang java --stdin`. No temp files required.
+- [DS1e] **Efficiency**: Do not extract full JARs. Use CLI piping for instant access.
 
 ## [FS1] File Creation & Type Safety
 
@@ -40,6 +81,26 @@ alwaysApply: true
 - [FS1e] Domain has zero framework imports; dependencies point inward.
 - [FS1f] No generic utilities: reject `*Utils/*Helper/*Common`; use domain-specific names.
 - [FS1g] Domain value types: wrap identifiers, amounts, and values with invariants in records.
+- [FS1h] File size discipline: see [LOC1a] and [MO1a].
+
+## [LOC1] Line Count Ceiling (Repo-Wide)
+
+- [LOC1a] All written, non-generated source files in this repository MUST be <= 350 lines (`wc -l`), including `AGENTS.md`
+- [LOC1b] SRP Enforcer: This 350-line "stick" forces modularity (DDD/SRP); > 350 lines = too many responsibilities (see [MO1d])
+- [LOC1c] Zero Tolerance: No edits allowed to files > 350 LOC (even legacy); you MUST split/retrofit before applying your change
+- [LOC1d] Enforcement: run line count checks and treat failures as merge blockers
+- [LOC1e] Exempt files: generated content, lockfiles, and large example/data dumps
+
+## [MO1] No Monoliths
+
+- [MO1a] No monoliths: avoid multi-concern files and catch-all modules
+- [MO1b] New work starts in new files; when touching a monolith, extract at least one seam
+- [MO1c] If safe extraction impossible, halt and ask
+- [MO1d] Strict SRP: each unit serves one actor; separate logic that changes for different reasons
+- [MO1e] Boundary rule: cross-module interaction happens only through explicit, typed contracts with dependencies pointing inward; don’t reach into other modules’ internals or mix web/use-case/domain/persistence concerns in one unit
+- [MO1f] Decision Logic: New feature → New file; Bug fix → Edit existing; Logic change → Extract/Replace
+- [MO1g] Extension (OCP): Add functionality via new classes/composition; do not modify stable code to add features
+-   Contract: `docs/contracts/code-change.md`
 
 ## [ND1] Naming Discipline
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 [![Context7](src/main/resources/static/img/context7-badge.svg)](https://context7.com/williamagh/apple-maps-java)
 [![DeepWiki](src/main/resources/static/img/deepwiki-badge.svg)](https://deepwiki.com/WilliamAGH/apple-maps-java)
+[![Docs](https://img.shields.io/badge/docs-mintlify-18b884)](https://www.mintlify.com/WilliamAGH/apple-maps-java)
 
 # Apple Maps Server SDK for Java
 
@@ -38,6 +39,8 @@ Apple provides three primary ways to integrate Maps. This library supports #1 (S
 
 ## Installation
 
+> Latest stable release: **0.1.5** — [view on Maven Central](https://central.sonatype.com/artifact/com.williamcallahan/apple-maps-java) | [view on mvnrepository](https://mvnrepository.com/artifact/com.williamcallahan/apple-maps-java)
+
 This repo’s build uses a Gradle Java toolchain (Java 17). If you don’t have JDK 17 installed locally, Gradle will download it automatically.
 
 ### Gradle
@@ -60,11 +63,7 @@ dependencies {
 
 ### Snapshots
 
-Snapshots are published to Sonatype's snapshot repository (separate from Maven Central releases):
-
-```text
-https://central.sonatype.com/repository/maven-snapshots/
-```
+Snapshots are published automatically on every push to `main` and are available from Sonatype’s snapshot repository (separate from Maven Central releases).
 
 Gradle:
 
@@ -94,6 +93,14 @@ Maven:
     </snapshots>
   </repository>
 </repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>com.williamcallahan</groupId>
+    <artifactId>apple-maps-java</artifactId>
+    <version>0.1.6-SNAPSHOT</version>
+  </dependency>
+</dependencies>
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -58,6 +58,44 @@ dependencies {
 </dependency>
 ```
 
+### Snapshots
+
+Snapshots are published to Sonatype's snapshot repository (separate from Maven Central releases):
+
+```text
+https://central.sonatype.com/repository/maven-snapshots/
+```
+
+Gradle:
+
+```groovy
+repositories {
+    mavenCentral()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+}
+
+dependencies {
+    implementation("com.williamcallahan:apple-maps-java:0.1.6-SNAPSHOT")
+}
+```
+
+Maven:
+
+```xml
+<repositories>
+  <repository>
+    <id>sonatype-snapshots</id>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <releases>
+      <enabled>false</enabled>
+    </releases>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+```
+
 ## Configuration
 
 ### `APPLE_MAPS_TOKEN` (required)

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -1,3 +1,7 @@
+---
+title: "Authorization (Apple Maps Server API)"
+---
+
 # Authorization (Apple Maps Server API)
 
 To call the Apple Maps Server API, you must provide an Apple-issued **authorization token** (a JWT).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,3 +1,7 @@
+---
+title: "CLI"
+---
+
 # CLI
 
 This repo includes a small CLI for running Apple Maps Server queries from your terminal.

--- a/docs/contracts/code-change.md
+++ b/docs/contracts/code-change.md
@@ -1,0 +1,111 @@
+---
+title: "Code change policy contract"
+usage: "Use whenever creating/modifying files: where to put code, when to create new types, and how to stay SRP/DDD compliant"
+description: "Evergreen contract for change decisions (new file vs edit), repository structure/naming, and domain model hierarchy; references rule IDs in `AGENTS.md`"
+---
+
+# Code Change Policy Contract
+
+See `AGENTS.md` ([LOC1a-e], [MO1a-g], [FS1a-h], [ND1a-c], [CC1a-d], [TS1a-d], [VR1a-c]).
+
+## Non-negotiables (applies to every change)
+
+- **SRP/DDD only**: each new type/method has one reason to change ([MO1d], [CC1a]).
+- **New feature → new file**; do not grow monoliths ([MO1b], [FS1b]).
+- **No edits to >350 LOC files**; first split/retrofit ([LOC1c]).
+- **Domain is framework-free**; dependencies point inward ([CC1d], [FS1e]).
+- **No DTOs**; domain records/interfaces are the API response types.
+- **No map payloads** (`Map<String,Object>`, stringly helpers, map-based mappers) ([ZA1c], [FS1b]).
+
+## Decision matrix: create new file vs edit existing
+
+Use this as a hard rule, not a suggestion.
+
+| Situation | MUST do | MUST NOT do |
+|----------|---------|-------------|
+| New user-facing behavior (new endpoint, new domain capability) | Add a new, narrowly scoped type in the correct layer/package ([MO1b]) | “Just add a method” to an unrelated class ([MO1a], [MO1d]) |
+| Bug fix (existing behavior wrong) | Edit the smallest correct owner; add/adjust tests to lock behavior ([MO1f], [TS1a]) | Create a parallel/shadow implementation ([RC1d]) |
+| Logic change in stable code | Extract/replace via composition; keep stable code stable ([MO1g]) | Add flags, shims, or “compat” paths to hide uncertainty ([RC1e]) |
+| Touching a large/overloaded file | Extract at least one seam (new type + typed contract) ([MO1b], [MO1e]) | Grow the file further ([MO1a]) |
+| Reuse needed across features | Add a domain value object / explicit port / explicit service with intent-revealing name ([CS1a], [AR1c], [ND1a]) | Add `*Utils/*Helper/*Common/*Base*` grab bags ([FS1f]) |
+
+### When adding a method is allowed
+
+Adding to an existing type is allowed only when all are true:
+
+- It is the **same responsibility** as the type’s existing purpose ([MO1d]).
+- The method’s inputs belong together (avoid data clumps/long parameter lists; extract a parameter record when needed) ([CS1b], [CS1c]).
+- The method does not pull in a new dependency direction (dependencies still point inward) ([CC1d]).
+
+If any bullet fails, create a new type and inject it explicitly.
+
+## Create-new-type checklist (before you write code)
+
+1. **Search/reuse first**: confirm a type/pattern doesn’t already exist ([FS1a], [ZA1a]).
+2. **Pick the correct layer** (web → use case → domain → adapters/out) ([AR1a]).
+3. **Pick the correct feature package** (feature-first, lowercase, singular nouns).
+4. **Name by role** (ban generic names; suffix declares meaning) ([ND1a-b]).
+5. **Keep the file small** (stay comfortably under 350 LOC; split by concept early) ([LOC1a], [MO1d]).
+6. **Add/adjust tests** using existing patterns/utilities ([TS1a], [TS1b]).
+7. **Verify** with repo-standard commands (`./gradlew build`, `./gradlew spotlessCheck`) ([VR1a], [VR1c]).
+
+## Repository structure and naming (placement is part of the contract)
+
+### Canonical roots (Java)
+
+Only these root packages are allowed ([AR1a]):
+
+- `com.williamcallahan.applemaps.boot`
+- `com.williamcallahan.applemaps.adapters`
+- `com.williamcallahan.applemaps.cli`
+- `com.williamcallahan.applemaps.domain`
+
+### Feature-first package rule
+
+All layers organize by **feature first**, then by role.
+
+Examples:
+- `domain/model/place/...`
+- `domain/port/place/...`
+- `adapters/mapsserver/...`
+
+### No mixed packages
+
+A package contains either:
+- Direct classes only, or
+- Subpackages only (plus optional `package-info.java`).
+
+If you need both, insert one more nesting level.
+
+## Domain model hierarchy
+
+- Domain records are immutable value objects.
+- Validation happens in constructors.
+- Domain → API mapping happens once at the boundary.
+
+## Layer responsibility contract
+
+### Controllers / CLI
+
+Allowed:
+- Bind/validate inputs.
+- Delegate to use cases/domain services.
+- Return domain records.
+
+Prohibited:
+- Business logic.
+
+### Domain
+
+Allowed:
+- Pure business logic.
+- Invariants.
+
+Prohibited:
+- Framework imports.
+- Persistence details.
+
+## Verification gates (do not skip)
+
+- LOC enforcement: manual check / script ([LOC1c]).
+- Build/test/lint: `./gradlew build` ([VR1a]).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Apple Maps Server SDK for Java",
+  "colors": {
+    "primary": "#007ec6"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting Started",
+        "pages": [
+          "usage",
+          "authorization"
+        ]
+      },
+      {
+        "group": "CLI",
+        "pages": [
+          "cli"
+        ]
+      },
+      {
+        "group": "Testing",
+        "pages": [
+          "tests"
+        ]
+      },
+      {
+        "group": "Contracts",
+        "pages": [
+          "contracts/code-change"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,3 +1,7 @@
+---
+title: "Tests"
+---
+
 # Tests
 
 This repo has unit tests and an optional integration test that calls the live Apple Maps Server API.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,7 @@
+---
+title: "Usage"
+---
+
 # Usage
 
 ## Quick start

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.williamcallahan
 POM_ARTIFACT_ID=apple-maps-java
-VERSION_NAME=0.1.5
+VERSION_NAME=0.1.6-SNAPSHOT
 
 POM_NAME=Apple Maps Java
 POM_DESCRIPTION=Apple Maps Java implements the Apple Maps Server API for use in JVMs.


### PR DESCRIPTION
Mirrors the Maven Central publishing guardrails used in tui4j.

Changes:
- Release workflow: fail fast if the release tag ends with -SNAPSHOT (Central releases reject SNAPSHOTs).
- CI workflow: only publish snapshots when VERSION_NAME ends with -SNAPSHOT; publish snapshots without overriding -Pversion (uses gradle.properties).
- gradle.properties: bump VERSION_NAME to 0.1.6-SNAPSHOT.
- README: document Sonatype snapshot repository + snapshot dependency coordinates.

Verification:
- ./gradlew build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds guardrails to prevent SNAPSHOT versions from being published to Maven Central, bumps `VERSION_NAME` to `0.1.6-SNAPSHOT`, and documents the Sonatype snapshot repository in the README. The CI and Release workflow changes are clean and correct.

- **P1 — README snapshot coordinates will be overwritten**: The new snapshot section in `README.md` contains `implementation(\"com.williamcallahan:apple-maps-java:0.1.6-SNAPSHOT\")` and the matching Maven `<version>0.1.6-SNAPSHOT</version>`. The pre-existing `UpdateReadmeVersion.yaml` perl substitutions use the `/g` flag and will replace **all** matching coordinates globally — including those in the snapshot section — with the latest stable version from Maven Central on its next run (daily schedule or next release trigger). The `UpdateReadmeVersion` script needs its regexes scoped to non-SNAPSHOT versions before this README section can be trusted.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the UpdateReadmeVersion regex scope, which will otherwise silently corrupt the new snapshot docs on its next run.

All CI/workflow logic changes are correct and well-structured. The sole P1 finding is in README.md: the existing global regex in UpdateReadmeVersion.yaml will overwrite the new snapshot coordinates with the stable release version, breaking the snapshot documentation for consumers.

README.md (snapshot section) and .github/workflows/UpdateReadmeVersion.yaml (perl regex scope)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/CI.yaml | Refactored snapshot detection: version check now reads the SNAPSHOT suffix from gradle.properties rather than appending it; publish step correctly conditioned on is_snapshot=true; no issues. |
| .github/workflows/Release.yaml | Added SNAPSHOT guard that fails fast when the release tag resolves to a -SNAPSHOT version; correctly positioned before build/publish steps. |
| .github/workflows/UpdateReadmeVersion.yaml | ref: main checkout added (correct); however its global perl regex will overwrite the new snapshot version coordinates in README.md on the next run. |
| README.md | New snapshot repo section added with correct coordinates; however, the pre-existing UpdateReadmeVersion automation will corrupt the snapshot version on its next run due to global regex replacement. |
| gradle.properties | VERSION_NAME bumped from 0.1.5 to 0.1.6-SNAPSHOT; straightforward and correct. |
| AGENTS.md | Expanded rule set (ZA1, GT1, CC1, ID1, DS1, LOC1, MO1); file is 161 lines, comfortably under the 350-line ceiling defined in LOC1a. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B{version_check:\nVERSION_NAME ends\nwith -SNAPSHOT?}
    B -- Yes --> C[Publish SNAPSHOT\npublishAllPublicationsToCentralPortalSnapshots]
    B -- No --> D[Skip publish]

    E[GitHub Release published] --> F[Extract version\nfrom tag]
    F --> G{Fail if SNAPSHOT tag:\nVERSION ends with\n-SNAPSHOT?}
    G -- Yes --> H[Exit 1\nRefuse SNAPSHOT release]
    G -- No --> I[Build & Test\n-Pversion=TAG]
    I --> J[Deploy to Maven Central\npublishAllPublicationsToCentralPortal]

    K[Daily schedule / release trigger] --> L[UpdateReadmeVersion:\nFetch latest stable\nfrom Maven Central]
    L --> M{Resolved version\nis SNAPSHOT?}
    M -- Yes --> N[Exit 1\nRefuse SNAPSHOT update]
    M -- No --> O[Perl regex /g:\nupdates ALL coords\nincl. snapshot section]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A77-102%0A**%60UpdateReadmeVersion%60%20will%20overwrite%20snapshot%20coordinates%20with%20the%20stable%20version**%0A%0AThe%20%60UpdateReadmeVersion.yaml%60%20perl%20substitutions%20use%20the%20%60%2Fg%60%20%28global%29%20flag%2C%20so%20they%20match%20**all**%20occurrences%20of%20the%20dependency%20coordinates%20in%20the%20file%20%E2%80%94%20including%20the%20new%20snapshot%20section.%20The%20next%20time%20that%20workflow%20runs%20%28daily%20schedule%2C%20or%20on%20the%20next%20release%29%2C%20it%20will%20replace%20%600.1.6-SNAPSHOT%60%20in%20both%20the%20Gradle%20and%20Maven%20snapshot%20snippets%20with%20the%20latest%20Maven%20Central%20stable%20version%20%28e.g.%2C%20%600.1.5%60%29%2C%20silently%20corrupting%20the%20documentation%20for%20consumers%20who%20rely%20on%20snapshots.%0A%0AThe%20simplest%20fix%20is%20to%20guard%20the%20regex%20so%20it%20only%20touches%20non-SNAPSHOT%20versions%3A%0A%0A%60%60%60perl%0A%23%20Gradle%20snippet%20%E2%80%94%20stable%20only%0As%2F%28implementation%5C%28%22com%5C.williamcallahan%3Aapple-maps-java%3A%29%28%3F!.*SNAPSHOT%29%5B%5E%22%5D%2B%28%22%5C%29%29%2F%241%24v%242%2Fg%3B%0A%0A%23%20Maven%20snippet%20%E2%80%94%20stable%20only%0As%23%28%3Cdependency%3E%5Cs*%3CgroupId%3Ecom%5C.williamcallahan%3C%2FgroupId%3E%5Cs*%3CartifactId%3Eapple-maps-java%3C%2FartifactId%3E%5Cs*%3Cversion%3E%29%28%3F!.*SNAPSHOT%29%5B%5E%3C%5D%2B%28%3C%2Fversion%3E%5Cs*%3C%2Fdependency%3E%29%23%241%24v%242%23gms%3B%0A%60%60%60%0A%0AAlternatively%2C%20wrap%20each%20stable%20snippet%20in%20HTML%20comment%20markers%20and%20scope%20the%20replacement%20to%20only%20that%20region.%0A%0A&repo=williamagh%2Fapple-maps-java"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A77-102%0A**%60UpdateReadmeVersion%60%20will%20overwrite%20snapshot%20coordinates%20with%20the%20stable%20version**%0A%0AThe%20%60UpdateReadmeVersion.yaml%60%20perl%20substitutions%20use%20the%20%60%2Fg%60%20%28global%29%20flag%2C%20so%20they%20match%20**all**%20occurrences%20of%20the%20dependency%20coordinates%20in%20the%20file%20%E2%80%94%20including%20the%20new%20snapshot%20section.%20The%20next%20time%20that%20workflow%20runs%20%28daily%20schedule%2C%20or%20on%20the%20next%20release%29%2C%20it%20will%20replace%20%600.1.6-SNAPSHOT%60%20in%20both%20the%20Gradle%20and%20Maven%20snapshot%20snippets%20with%20the%20latest%20Maven%20Central%20stable%20version%20%28e.g.%2C%20%600.1.5%60%29%2C%20silently%20corrupting%20the%20documentation%20for%20consumers%20who%20rely%20on%20snapshots.%0A%0AThe%20simplest%20fix%20is%20to%20guard%20the%20regex%20so%20it%20only%20touches%20non-SNAPSHOT%20versions%3A%0A%0A%60%60%60perl%0A%23%20Gradle%20snippet%20%E2%80%94%20stable%20only%0As%2F%28implementation%5C%28%22com%5C.williamcallahan%3Aapple-maps-java%3A%29%28%3F!.*SNAPSHOT%29%5B%5E%22%5D%2B%28%22%5C%29%29%2F%241%24v%242%2Fg%3B%0A%0A%23%20Maven%20snippet%20%E2%80%94%20stable%20only%0As%23%28%3Cdependency%3E%5Cs*%3CgroupId%3Ecom%5C.williamcallahan%3C%2FgroupId%3E%5Cs*%3CartifactId%3Eapple-maps-java%3C%2FartifactId%3E%5Cs*%3Cversion%3E%29%28%3F!.*SNAPSHOT%29%5B%5E%3C%5D%2B%28%3C%2Fversion%3E%5Cs*%3C%2Fdependency%3E%29%23%241%24v%242%23gms%3B%0A%60%60%60%0A%0AAlternatively%2C%20wrap%20each%20stable%20snippet%20in%20HTML%20comment%20markers%20and%20scope%20the%20replacement%20to%20only%20that%20region.%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A77-102%0A**%60UpdateReadmeVersion%60%20will%20overwrite%20snapshot%20coordinates%20with%20the%20stable%20version**%0A%0AThe%20%60UpdateReadmeVersion.yaml%60%20perl%20substitutions%20use%20the%20%60%2Fg%60%20%28global%29%20flag%2C%20so%20they%20match%20**all**%20occurrences%20of%20the%20dependency%20coordinates%20in%20the%20file%20%E2%80%94%20including%20the%20new%20snapshot%20section.%20The%20next%20time%20that%20workflow%20runs%20%28daily%20schedule%2C%20or%20on%20the%20next%20release%29%2C%20it%20will%20replace%20%600.1.6-SNAPSHOT%60%20in%20both%20the%20Gradle%20and%20Maven%20snapshot%20snippets%20with%20the%20latest%20Maven%20Central%20stable%20version%20%28e.g.%2C%20%600.1.5%60%29%2C%20silently%20corrupting%20the%20documentation%20for%20consumers%20who%20rely%20on%20snapshots.%0A%0AThe%20simplest%20fix%20is%20to%20guard%20the%20regex%20so%20it%20only%20touches%20non-SNAPSHOT%20versions%3A%0A%0A%60%60%60perl%0A%23%20Gradle%20snippet%20%E2%80%94%20stable%20only%0As%2F%28implementation%5C%28%22com%5C.williamcallahan%3Aapple-maps-java%3A%29%28%3F!.*SNAPSHOT%29%5B%5E%22%5D%2B%28%22%5C%29%29%2F%241%24v%242%2Fg%3B%0A%0A%23%20Maven%20snippet%20%E2%80%94%20stable%20only%0As%23%28%3Cdependency%3E%5Cs*%3CgroupId%3Ecom%5C.williamcallahan%3C%2FgroupId%3E%5Cs*%3CartifactId%3Eapple-maps-java%3C%2FartifactId%3E%5Cs*%3Cversion%3E%29%28%3F!.*SNAPSHOT%29%5B%5E%3C%5D%2B%28%3C%2Fversion%3E%5Cs*%3C%2Fdependency%3E%29%23%241%24v%242%23gms%3B%0A%60%60%60%0A%0AAlternatively%2C%20wrap%20each%20stable%20snippet%20in%20HTML%20comment%20markers%20and%20scope%20the%20replacement%20to%20only%20that%20region.%0A%0A&repo=williamagh%2Fapple-maps-java"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 77-102

Comment:
**`UpdateReadmeVersion` will overwrite snapshot coordinates with the stable version**

The `UpdateReadmeVersion.yaml` perl substitutions use the `/g` (global) flag, so they match **all** occurrences of the dependency coordinates in the file — including the new snapshot section. The next time that workflow runs (daily schedule, or on the next release), it will replace `0.1.6-SNAPSHOT` in both the Gradle and Maven snapshot snippets with the latest Maven Central stable version (e.g., `0.1.5`), silently corrupting the documentation for consumers who rely on snapshots.

The simplest fix is to guard the regex so it only touches non-SNAPSHOT versions:

```perl
# Gradle snippet — stable only
s/(implementation\("com\.williamcallahan:apple-maps-java:)(?!.*SNAPSHOT)[^"]+("\))/$1$v$2/g;

# Maven snippet — stable only
s#(<dependency>\s*<groupId>com\.williamcallahan</groupId>\s*<artifactId>apple-maps-java</artifactId>\s*<version>)(?!.*SNAPSHOT)[^<]+(</version>\s*</dependency>)#$1$v$2#gms;
```

Alternatively, wrap each stable snippet in HTML comment markers and scope the replacement to only that region.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Mintlify badge, mvnrepository ..."](https://github.com/williamagh/apple-maps-java/commit/c251a8b753d29d99d819510db36417b84d718073) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=23051360)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->